### PR TITLE
rename presentation.md --> introduction.md

### DIFF
--- a/content/pages/introduction.md
+++ b/content/pages/introduction.md
@@ -1,7 +1,7 @@
-Title: Presentation
+Title: Introduction
 Order: 1
 Date: 2015-08-11
-Slug: presentation
+Slug: introduction
 Authors: cgeek
 
 Duniter is a _cryptocurrency software_, which means it is a **software** providing the ability to **create currencies**. Duniter is different from other cryptocurrency softwares you may know (Bitcoin, Litecoin, Peercoin, ...) for 2 main reasons : its **currency code** includes the concepts of a [Universal Dividend](https://en.wikipedia.org/wiki/Social_credit) and [Web of Trust](https://en.wikipedia.org/wiki/Web_of_trust); but also its **Blockchain code**, which is far more energy efficient, getting rid of the massive waste of energy introduced by Bitcoin.

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -65,7 +65,7 @@ LINKS = (('duniter.org', 'https://duniter.org/'),
          ('creationmonetaire.info', 'http://creationmonetaire.info/'),)
 
 # Social widget
-ACCEPTED_MENUS = ['presentation',
+ACCEPTED_MENUS = ['introduction',
          'get-g1',
          'contribute',
          'contact',


### PR DESCRIPTION
In English, "presentation" usually refers to a particular object or event related to presenting an idea to an audience (say, a slideshow presentation, or a public session where an announcement is made) rather than the actual content of such an action. This is actually the meaning already used on this site, e.g [here](https://duniter.org/en/recap-of-the-5th-fmm-4-days-focusing-on-money-systems/) and [here](https://duniter.org/en/ucoin-at-the-5th-freedom-money-meeting/), so using it in a different way introduces unnecessary ambiguity.

For websites, the term most likely to convey the intended meaning here is "about", but that's already taken by [another page](https://github.com/duniter/website_en/blob/master/content/pages/about.md) (which should IMO be called "credits", but that's already taken by *[yet another](https://github.com/duniter/website_en/blob/master/content/pages/credits.md)* page!), so rather than shuffling these pages around, I'm proposing "introduction" instead.